### PR TITLE
PCSL-24 change swift version

### DIFF
--- a/ios/RNNoke.xcodeproj/project.pbxproj
+++ b/ios/RNNoke.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -252,7 +253,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "RNNoke-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -272,7 +273,7 @@
 				PRODUCT_NAME = RNNoke;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "RNNoke-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-noke",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "Noke SDK for React-Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update Swift version to 4.0. Bump version.

The merge commit should be tagged with `v3.0.14`. This needs to be done *before* `smartlock#PCSL-24-change-swift-verison-of-react-native-noke` is merged.